### PR TITLE
Introduce Python 3 support

### DIFF
--- a/check_rabbitmq_queues/check.py
+++ b/check_rabbitmq_queues/check.py
@@ -136,13 +136,13 @@ def run(config=DEFAULT_CONFIG):
     stats, errors = check_lengths(client, vhost, queues)
 
     if errors['critical']:
-        print 'CRITICAL - %s.' % format_status(errors['critical'], stats)
+        print('CRITICAL - %s.' % format_status(errors['critical'], stats))
         sys.exit(2)
     elif errors['warning']:
-        print 'WARNING - %s.' % format_status(errors['warning'], stats)
+        print('WARNING - %s.' % format_status(errors['warning'], stats))
         sys.exit(1)
     else:
-        print 'OK - all lengths fine.'
+        print('OK - all lengths fine.')
         sys.exit(0)
 
 
@@ -154,7 +154,7 @@ def main():
     try:
         dispatch_command(run)
     except Exception as e:
-        print 'WARNING - unhandled Exception: %s' % str(e)
+        print('WARNING - unhandled Exception: %s' % str(e))
         if os.getenv('CHECK_QUEUES_DEBUG'):
             import traceback
             traceback.print_exc()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 setup(name='check-rabbitmq-queues',
-      version='1.0.3',
+      version='1.1.0',
       description='Package for checking current length of RabbitMQ queues.',
       author='Opera Services Team',
       author_email='svc-code@opera.com',

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[tox]
+envlist = py27,py36
+
 [testenv]
 deps =
     mock==1.0.1


### PR DESCRIPTION
We use this in `some-project-connected-with-thumbnails-uploading-which-NDA-probably-forbids-me-to-talk-about-publicly` and found out it no longer does its job after upgrading to py3. Fortunately `2to3` handled this.