### PR TITLE
Allow RabbitMQ username and password to be supplied via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ queues:
         warning: 0
 ```
 
+You can also provide username and password in `CHECK_RABBITMQ_QUEUES_USERNAME` and `CHECK_RABBITMQ_QUEUES_PASSWORD`
+environmental variables instead if you wish.
+
 ## Tests ##
 In project directory:
 ```

--- a/check_rabbitmq_queues/check.py
+++ b/check_rabbitmq_queues/check.py
@@ -45,10 +45,13 @@ def get_client(cfg):
     :param cfg: config dict
     :return: RabbitMQ client object
     """
+    username_from_env = os.getenv('CHECK_RABBITMQ_QUEUES_USERNAME')
+    password_from_env = os.getenv('CHECK_RABBITMQ_QUEUES_PASSWORD')
+
     client = Client('%s:%s' % (cfg.get('host', DEFAULT_HOSTNAME),
                                cfg.get('port', DEFAULT_PORT)),
-                    cfg.get('username', DEFAULT_USERNAME),
-                    cfg.get('password', DEFAULT_PASSWORD))
+                    username_from_env or cfg.get('username', DEFAULT_USERNAME),
+                    password_from_env or cfg.get('password', DEFAULT_PASSWORD))
     return client
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 setup(name='check-rabbitmq-queues',
-      version='1.1.0',
+      version='1.2.0',
       description='Package for checking current length of RabbitMQ queues.',
       author='Opera Services Team',
       author_email='svc-code@opera.com',


### PR DESCRIPTION
@r4fek 