### PR TITLE
Refactor check so queues could be watched by prefixes

### DIFF
--- a/check_rabbitmq_queues/check.py
+++ b/check_rabbitmq_queues/check.py
@@ -126,7 +126,6 @@ def check_lengths(queues, queue_conf, queue_prefix_conf):
     for q in missing:
         stats[q] = 'Queue not found'
 
-    print(stats)
     if errors:
         raise RabbitCritical(errors, stats)
     elif warnings:

--- a/check_rabbitmq_queues/check.py
+++ b/check_rabbitmq_queues/check.py
@@ -27,12 +27,20 @@ DEFAULT_HOSTNAME = 'localhost'
 DEFAULT_PORT = 15672
 
 
-class RabbitWarning(Exception):
-    pass
+class RabbitException(Exception):
+    error_code = 1
+
+    def __init__(self, errors, stats={}):
+        self.errors = errors
+        self.stats = stats
 
 
-class RabbitCritical(Exception):
-    pass
+class RabbitWarning(RabbitException):
+    error_code = 1
+
+
+class RabbitCritical(RabbitException):
+    error_code = 2
 
 
 def get_config(config_path):
@@ -149,8 +157,7 @@ def get_queues(client, vhost):
             warning = 'Unauthorized.'
         else:
             warning = 'Unhandled HTTP error, status: %s' % e.status
-        print('WARNING - %s.' % warning)
-        raise RabbitWarning()
+        raise RabbitWarning(['all'], {'all': warning})
 
 
 @arg('-c', '--config', help='Path to config')

--- a/check_rabbitmq_queues/tests/test_check.py
+++ b/check_rabbitmq_queues/tests/test_check.py
@@ -3,7 +3,12 @@ from unittest import TestCase
 from mock import patch, Mock
 from pyrabbit.http import NetworkError, HTTPError
 
-from check_rabbitmq_queues.check import check_lengths, run
+from check_rabbitmq_queues.check import (
+    check_lengths,
+    get_queues,
+    RabbitWarning,
+    run,
+)
 
 MODULE = 'check_rabbitmq_queues.check'
 
@@ -90,6 +95,51 @@ class CheckLengthsTestCase(TestCase):
         self.assertEqual(
             stats, {'foo': 'Unhandled HTTP error, status: 500'})
         self.assertEqual(errors, {'critical': [], 'warning': ['foo']})
+
+
+class GetQueuesTestCase(TestCase):
+
+    def setUp(self):
+        self.client_mock = Mock()
+        self.vhost_mock = Mock()
+
+    def test_ok(self):
+        res = get_queues(self.client_mock, self.vhost_mock)
+
+        self.assertEqual(res, self.client_mock.get_queues.return_value)
+        self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
+
+    def test_network_error(self):
+        self.client_mock.get_queues.side_effect = NetworkError()
+
+        with self.assertRaises(RabbitWarning):
+            get_queues(self.client_mock, self.vhost_mock)
+
+        self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
+
+    def test_404(self):
+        self.client_mock.get_queues.side_effect = HTTPError('', status=404)
+
+        with self.assertRaises(RabbitWarning):
+            get_queues(self.client_mock, self.vhost_mock)
+
+        self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
+
+    def test_401(self):
+        self.client_mock.get_queues.side_effect = HTTPError('', status=401)
+
+        with self.assertRaises(RabbitWarning):
+            get_queues(self.client_mock, self.vhost_mock)
+
+        self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
+
+    def test_unknown_error(self):
+        self.client_mock.get_queues.side_effect = HTTPError('', status=500)
+
+        with self.assertRaises(RabbitWarning):
+            get_queues(self.client_mock, self.vhost_mock)
+
+        self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
 
 
 @patch(MODULE + '.get_config', Mock())

--- a/check_rabbitmq_queues/tests/test_check.py
+++ b/check_rabbitmq_queues/tests/test_check.py
@@ -112,33 +112,43 @@ class GetQueuesTestCase(TestCase):
     def test_network_error(self):
         self.client_mock.get_queues.side_effect = NetworkError()
 
-        with self.assertRaises(RabbitWarning):
+        with self.assertRaises(RabbitWarning) as excinfo:
             get_queues(self.client_mock, self.vhost_mock)
 
+        self.assertEqual(excinfo.exception.errors, ['all'])
+        self.assertEqual(excinfo.exception.stats,
+                         {'all': 'Can not communicate with RabbitMQ.'})
         self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
 
     def test_404(self):
         self.client_mock.get_queues.side_effect = HTTPError('', status=404)
 
-        with self.assertRaises(RabbitWarning):
+        with self.assertRaises(RabbitWarning) as excinfo:
             get_queues(self.client_mock, self.vhost_mock)
 
+        self.assertEqual(excinfo.exception.errors, ['all'])
+        self.assertEqual(excinfo.exception.stats, {'all': 'Queue not found.'})
         self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
 
     def test_401(self):
         self.client_mock.get_queues.side_effect = HTTPError('', status=401)
 
-        with self.assertRaises(RabbitWarning):
+        with self.assertRaises(RabbitWarning) as excinfo:
             get_queues(self.client_mock, self.vhost_mock)
 
+        self.assertEqual(excinfo.exception.errors, ['all'])
+        self.assertEqual(excinfo.exception.stats, {'all': 'Unauthorized.'})
         self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
 
     def test_unknown_error(self):
         self.client_mock.get_queues.side_effect = HTTPError('', status=500)
 
-        with self.assertRaises(RabbitWarning):
+        with self.assertRaises(RabbitWarning) as excinfo:
             get_queues(self.client_mock, self.vhost_mock)
 
+        self.assertEqual(excinfo.exception.errors, ['all'])
+        self.assertEqual(excinfo.exception.stats,
+                         {'all': 'Unhandled HTTP error, status: 500'})
         self.client_mock.get_queues.assert_called_once_with(self.vhost_mock)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 
 setup(name='check-rabbitmq-queues',
-      version='1.1.0',
+      version='1.2.0',
       description='Package for checking current length of RabbitMQ queues.',
       author='Opera Services Team',
       author_email='svc-code@opera.com',


### PR DESCRIPTION
Example config:
```yaml
host: localhost
port: 15672
username: guest
password: guest
vhost: /
queues:
    queue1:
        critical: 0
        warning: 0
    queue2:
        critical: 0
        warning: 0
queue_prefixes:
    prefix1:
        critical: 0
        warning: 0
```